### PR TITLE
Cleanup code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+coverage
 
 .vscode
 

--- a/packages/graphql-mirage/src/__test__/buildMocks.test.js
+++ b/packages/graphql-mirage/src/__test__/buildMocks.test.js
@@ -1,0 +1,70 @@
+const fs = require("fs");
+const path = require("path");
+const { times } = require("lodash");
+const schemaParser = require("easygraphql-parser");
+
+const { defaultBuiltInScalarBuilders } = require("../engine");
+const { mergeDataSources } = require("../helpers");
+const { buildMocks, mergeScenario } = require("../index");
+
+const typeDefs = fs.readFileSync(
+  path.join(__dirname, "example.schema.graphql"),
+  "utf8"
+);
+const schema = schemaParser(typeDefs);
+const testBuildMocks = (type, schema, defaults = {}, custom) =>
+  buildMocks(
+    type,
+    schema,
+    mergeDataSources(
+      {
+        typeBuilders: defaultBuiltInScalarBuilders,
+      },
+      defaults
+    ),
+    custom
+  );
+
+describe("Scenario", () => {
+  it("SCENARIO: selectors allows to select subscenario for Object Type", () => {
+    const defaultScenario = {
+      me: {
+        trips: times(5, () => ({
+          site: "Kennedy Space Center",
+          mission: { name: "Test Mission" },
+        })),
+      },
+    };
+
+    const actual = testBuildMocks(
+      "Launch",
+      schema,
+      {
+        scenario: defaultScenario,
+      },
+      {
+        scenario: mergeScenario(defaultScenario.me.trips[0], {
+          site: "Vandenberg Air Force Base",
+        }),
+      }
+    );
+
+    expect(actual.site).toEqual("Vandenberg Air Force Base");
+    expect(actual.mission.name).toEqual("Test Mission");
+  });
+
+  it("SCENARIO: works when selector cannot find subscenario", () => {
+    const actual = testBuildMocks(
+      "Launch",
+      schema,
+      {},
+      {
+        scenario: mergeScenario(undefined, {
+          site: "Kennedy Space Center",
+        }),
+      }
+    );
+
+    expect(actual.site).toEqual("Kennedy Space Center");
+  });
+});

--- a/packages/graphql-mirage/src/__test__/buildMocks.test.js
+++ b/packages/graphql-mirage/src/__test__/buildMocks.test.js
@@ -3,8 +3,6 @@ const path = require("path");
 const { times } = require("lodash");
 const schemaParser = require("easygraphql-parser");
 
-const { defaultBuiltInScalarBuilders } = require("../engine");
-const { mergeDataSources } = require("../helpers");
 const { buildMocks, mergeScenario } = require("../index");
 
 const typeDefs = fs.readFileSync(
@@ -12,18 +10,6 @@ const typeDefs = fs.readFileSync(
   "utf8"
 );
 const schema = schemaParser(typeDefs);
-const testBuildMocks = (type, schema, defaults = {}, custom) =>
-  buildMocks(
-    type,
-    schema,
-    mergeDataSources(
-      {
-        typeBuilders: defaultBuiltInScalarBuilders,
-      },
-      defaults
-    ),
-    custom
-  );
 
 describe("Scenario", () => {
   it("SCENARIO: selectors allows to select subscenario for Object Type", () => {
@@ -36,7 +22,7 @@ describe("Scenario", () => {
       },
     };
 
-    const actual = testBuildMocks(
+    const actual = buildMocks(
       "Launch",
       schema,
       {
@@ -54,7 +40,7 @@ describe("Scenario", () => {
   });
 
   it("SCENARIO: works when selector cannot find subscenario", () => {
-    const actual = testBuildMocks(
+    const actual = buildMocks(
       "Launch",
       schema,
       {},

--- a/packages/graphql-mirage/src/__test__/dataSources.test.js
+++ b/packages/graphql-mirage/src/__test__/dataSources.test.js
@@ -1,37 +1,52 @@
-const update = require('immutability-helper');
+const { times } = require("lodash");
+const update = require("immutability-helper");
 
 const {
   getScenarioFn,
   getTypeBuildersFn,
   getNameBuildersFn,
-} = require('../helpers');
+} = require("../helpers");
 
-describe('getScenario', () => {
+describe("getScenario", () => {
   const defaults = {
-    viewer: {
-      userName: 'lola23',
-      firstName: 'Lola',
+    me: {
+      userName: "ciobi", // String
+      children: [{}, { name: "Andreea" }, {}], // [Child]
+      trips: times(10, () => ({
+        rockets: [{ name: "Falcon 9" }, { name: "Falcon Heavy" }],
+      })), // [Launches -> { ..., rockets: [Rocket] }]
     },
+    countries: times(10, () => ({})),
   };
 
   const customData = {
-    viewer: {
-      userName: 'john69',
+    me: {
+      userName: "c10b10",
+      children: [{}],
     },
+    countries: times(5, () => ({
+      states: times(2, () => ({
+        name: "Arizona",
+      })),
+    })),
   };
 
-  it('merges defaults correctly', () => {
+  it("merges defaults correctly", () => {
     const actual = getScenarioFn(defaults)(customData);
-    expect(actual.viewer.userName).toEqual(customData.viewer.userName);
-    expect(actual.viewer.firstName).toEqual(defaults.viewer.firstName);
+    expect(actual.me.userName).toEqual(customData.me.userName);
+    expect(actual.me.children).toHaveLength(customData.me.children.length);
+    expect(actual.me.trips).toHaveLength(defaults.me.trips.length);
+    expect(actual.countries).toHaveLength(5);
+    expect(actual.countries[0].states).toHaveLength(2);
+    expect(actual.countries[0].states[0].name).toBe("Arizona");
   });
 
-  it('gets memoized by using the customData object shape', () => {
+  it("gets memoized by using the customData object shape", () => {
     const getScenario = getScenarioFn(defaults);
 
     const expected = getScenario(
       update(customData, {
-        viewer: { userName: { $set: customData.viewer.userName } },
+        me: { userName: { $set: customData.me.userName } },
       })
     );
     const actual = getScenario(customData);
@@ -39,44 +54,34 @@ describe('getScenario', () => {
     expect(actual === expected).toBe(true);
   });
 
-  it('handle nulls', () => {
-    const actual = getScenarioFn(null)({ viewer: { userName: 'lena' } });
+  it("handle nulls", () => {
+    const actual = getScenarioFn(null)({ me: { userName: "c10b10" } });
 
-    expect(actual.viewer.userName).toBe('lena');
+    expect(actual.me.userName).toBe("c10b10");
   });
 });
 
-describe('getNameBuilders', () => {
-  // TODO: investigate why the lib is not merging correctly more than 1 level deep
+describe("getNameBuilders", () => {
   const defaults = {
-    city: {
-      name: 'Cluj-Napoca',
-    },
-    address: {
-      line1: 'Eroilor Boulevard, no 15',
-      description: 'Hip part of the city',
-    },
-    loremIpsum: 'sid dolor',
+    city: "Cluj-Napoca",
+    address: "Eroilor Street",
+    description: "Lorem ipsum",
   };
   const customData = {
-    address: {
-      line1: 'George Baritiu, no 29',
-      description: 'The best coffee in the city',
-    },
-    testKey: true,
+    address: "Unirii Square",
+    test: true,
   };
 
-  it('getNameBuilders: merges the custom data correctly', () => {
+  it("getNameBuilders: merges the custom data correctly", () => {
     const actual = getNameBuildersFn(defaults)(customData);
 
-    expect(actual.city.name).toEqual(defaults.city.name);
-    expect(actual.address.line1).toEqual(customData.address.line1);
-    expect(actual.address.description).toEqual(customData.address.description);
-    expect(actual.loremIpsum).toEqual(defaults.loremIpsum);
-    expect(actual.testKey).toBe(true);
+    expect(actual.city).toEqual(defaults.city);
+    expect(actual.address).toEqual(customData.address);
+    expect(actual.description).toEqual(defaults.description);
+    expect(actual.test).toBe(true);
   });
 
-  it('gets memoized by using the customData object shape', () => {
+  it("gets memoized by using the customData object shape", () => {
     const getNameBuilders = getNameBuildersFn(defaults);
 
     const expected = getNameBuilders({
@@ -88,36 +93,28 @@ describe('getNameBuilders', () => {
   });
 });
 
-describe('getTypeBuilders', () => {
+describe("getTypeBuilders", () => {
   const defaults = {
-    city: {
-      name: 'Cluj-Napoca',
-    },
-    address: {
-      line1: 'Eroilor Boulevard, no 15',
-      description: 'Hip part of the city',
-    },
-    loremIpsum: 'sid dolor',
-  };
-  const customData = {
-    address: {
-      line1: 'George Baritiu, no 29',
-      description: 'The best coffee in the city',
-    },
-    testKey: true,
+    city: "Cluj-Napoca",
+    address: "Eroilor Street",
+    description: "Lorem ipsum",
   };
 
-  it('getTypeBuilders: merges the custom data correctly', () => {
+  const customData = {
+    address: "Unirii Square",
+    test: true,
+  };
+
+  it("getTypeBuilders: merges the custom data correctly", () => {
     const actual = getNameBuildersFn(defaults)(customData);
 
-    expect(actual.city.name).toEqual(defaults.city.name);
-    expect(actual.address.line1).toEqual(customData.address.line1);
-    expect(actual.address.description).toEqual(customData.address.description);
-    expect(actual.loremIpsum).toEqual(defaults.loremIpsum);
-    expect(actual.testKey).toBe(true);
+    expect(actual.city).toEqual(defaults.city);
+    expect(actual.address).toEqual(customData.address);
+    expect(actual.description).toEqual(defaults.description);
+    expect(actual.test).toBe(true);
   });
 
-  it('gets memoized by using the customData object shape', () => {
+  it("gets memoized by using the customData object shape", () => {
     const getTypeBuilders = getTypeBuildersFn(defaults);
 
     const expected = getTypeBuilders({ ...customData });

--- a/packages/graphql-mirage/src/__test__/example.schema.graphql
+++ b/packages/graphql-mirage/src/__test__/example.schema.graphql
@@ -1,66 +1,117 @@
-type City {
-  id: ID!
-  name: String
-  population: Int
-  postalCodes: [String]
+type Query {
+  launches(
+    """
+    The number of results to show. Must be >= 1. Default = 20
+    """
+    pageSize: Int
+    """
+    If you add a cursor here, it will only return results _after_ this cursor
+    """
+    after: String
+    """
+    If you add this, the lauches will be filter by launch site name
+    """
+    siteFilter: String
+  ): LaunchConnection!
+  launch(id: ID!): Launch
+  me: User
 }
 
-type Address {
+type Mutation {
+  # if false, signup failed -- check errors
+  bookTrips(launchIds: [ID]!): TripUpdateResponse!
+  # if false, cancellation failed -- check errors
+  cancelTrip(launchId: ID!): TripUpdateResponse!
+  login(email: String): String # login token
+  # for use with the iOS tutorial
+  uploadProfileImage(file: Upload!): User
+}
+
+type TripUpdateResponse {
+  success: Boolean!
+  message: String
+  launches: [Launch]
+}
+
+"""
+Simple wrapper around our list of launches that contains a cursor to the
+last item in the list. Pass this cursor to the launches query to fetch results
+after these.
+"""
+type LaunchConnection {
+  cursor: String!
+  hasMore: Boolean!
+  list: [Launch]!
+}
+
+type Launch {
   id: ID!
-  line1: String
-  line2: String
-  city: City
-  postalCode: String
-  country: String
+  site: String
+  mission: Mission
+  rockets: [Rocket]
+  isBooked: Boolean!
+  destination: LaunchDestination
+}
+
+type Rocket {
+  id: ID!
+  name: String
+  type: String
+}
+
+type User {
+  id: ID!
+  email: String!
+  profileImage: String
+  gender: Gender
+  dateOfBirth: Date
+  allergies: [String]
+  trips: [Launch]!
+  hobbies: [Hobby]
+}
+
+type Mission {
+  name: String
+  missionPatch(size: PatchSize): String
+}
+
+interface LaunchDestination {
+  id: ID!
+  name: String
+}
+
+type Planet implements LaunchDestination {
+  id: ID!
+  name: String
   description: String
 }
 
-enum Technology {
-  JAVASCRIPT
-  GRAPHQL
-  NODEJS
-}
-
-scalar URL
-
-interface Persona {
+type Star implements LaunchDestination {
   id: ID!
-  firstName: String!
-  lastName: String!
-  userName: String!
-  age: Int
-  address: Address
-  avatar: URL
+  name: String
+  class: String
 }
 
-type Contributor implements Persona {
-  yearOfExperience: Int
-  knowledge: [Technology!]
+union Hobby = ReadingHobby | KarateHobby
+
+type ReadingHobby {
+  favoriteBook: String
+  favoriteGenre: String
 }
 
-type Customer implements Persona {
-  budget: Float!
-  looksForInvesting: Boolean!
+type KarateHobby {
+  belt: String
 }
 
-union User = Contributor | Customer
+scalar Date
 
-input UserFiltersInput {
-  age: Int
-  city: String
-  country: String
+enum Gender {
+  FEMALE
+  MALE
+  NON_BINARY
 }
 
-type UserListSearchResult {
-  list: [User]
-}
-
-type Query {
-  userList(filters: UserFiltersInput): UserListSearchResult
-  user(name: String): [User]
-  viewer: User
-}
-
-schema {
-  query: Query
+enum PatchSize {
+  SMALL
+  LARGE
 }

--- a/packages/graphql-mirage/src/__test__/example.schema.graphql
+++ b/packages/graphql-mirage/src/__test__/example.schema.graphql
@@ -65,9 +65,16 @@ type User {
   profileImage: String
   gender: Gender
   dateOfBirth: Date
+  address: Address
   allergies: [String]
   trips: [Launch]!
   hobbies: [Hobby]
+}
+
+type Address {
+  street: String
+  city: String
+  country: String
 }
 
 type Mission {

--- a/packages/graphql-mirage/src/__test__/helpers.test.js
+++ b/packages/graphql-mirage/src/__test__/helpers.test.js
@@ -1,0 +1,278 @@
+const fs = require("fs");
+const path = require("path");
+const schemaParser = require("easygraphql-parser");
+
+const { reduceDataSourcesToScenario } = require("../engine");
+
+const typeDefs = fs.readFileSync(
+  path.join(__dirname, "example.schema.graphql"),
+  "utf8"
+);
+const schema = schemaParser(typeDefs);
+
+const testReduceToScenario = (...args) => {
+  return reduceDataSourcesToScenario(...args, schema);
+};
+
+test("it works", () => {
+  expect(
+    testReduceToScenario(
+      {
+        name: "me",
+        type: "User",
+        isArray: false,
+      },
+      {
+        scenario: {
+          name: "Jim",
+          trips: [{ rockets: [{}, {}] }, { mission: "Unobtainium" }, {}],
+        },
+        typeBuilders: {
+          User: () => ({
+            emailAddress: "type@example.com",
+            trips: [{ isBooked: false }],
+          }),
+          String: () => "Mocked String",
+        },
+        nameBuilders: {
+          profileImage: () => "http://example.com/profile.png",
+          me: () => ({
+            allergies: ["Aspirin"],
+            address: {
+              city: "New York City",
+            },
+          }),
+        },
+      }
+    )
+  ).toEqual({
+    name: "Jim",
+    emailAddress: "type@example.com",
+    trips: [{ rockets: [{}, {}] }, { mission: "Unobtainium" }, {}],
+    allergies: ["Aspirin"],
+    address: {
+      city: "New York City",
+    },
+  });
+  // ^ For Object Type Builders, we expect the scenario to be composed
+  // by aggregating fields mockers from other builders
+
+  expect(
+    testReduceToScenario(
+      {
+        name: "trips",
+        type: "Launch",
+        isArray: true,
+      },
+      {
+        scenario: [{ rockets: [{}, {}] }, { mission: "Unobtainium" }, {}],
+        typeBuilders: {
+          User: () => ({
+            trips: [{ isBooked: false }],
+          }),
+          Launch: () => ({
+            site: "Kennedy Space Station",
+            mission: "Stargazing",
+            rockets: [{}],
+          }),
+          LaunchDestination: () => ({ name: "Mars" }),
+          String: () => "Mocked String",
+        },
+        nameBuilders: {
+          mission: () => "Tracking beetroot",
+        },
+      }
+    )
+  ).toEqual([
+    {
+      mission: "Stargazing",
+      rockets: [{}, {}],
+      site: "Kennedy Space Station",
+    },
+    { mission: "Unobtainium", rockets: [{}], site: "Kennedy Space Station" },
+    { mission: "Stargazing", rockets: [{}], site: "Kennedy Space Station" },
+  ]);
+  // ^ For arrays of Object Type builders we epect
+
+  expect(
+    testReduceToScenario(
+      {
+        name: "me",
+        type: "User",
+        isArray: false,
+      },
+      {
+        scenario: { name: "Jim" },
+        typeBuilders: {
+          User: () => ({
+            emailAddress: "type@example.com",
+          }),
+          String: () => "Mocked String",
+        },
+        nameBuilders: {
+          emailAddress: () => "hello@example.com",
+        },
+      }
+    )
+  ).toEqual({ name: "Jim", emailAddress: "type@example.com" });
+
+  expect(
+    testReduceToScenario(
+      {
+        name: "emailAddress",
+        type: "String",
+        isArray: false,
+      },
+      {
+        scenario: "example@test.com",
+        typeBuilders: {
+          User: () => ({
+            emailAddress: "type@example.com",
+          }),
+          String: () => "Mocked String",
+        },
+        nameBuilders: {
+          emailAddress: () => "hello@example.com",
+        },
+      }
+    )
+  ).toEqual("example@test.com");
+
+  expect(
+    testReduceToScenario(
+      {
+        name: "emailAddress",
+        type: "String",
+        isArray: false,
+      },
+      {
+        scenario: null,
+        typeBuilders: {
+          User: () => ({
+            emailAddress: "type@example.com",
+          }),
+          String: () => "Mocked String",
+        },
+        nameBuilders: {
+          emailAddress: () => "hello@example.com",
+        },
+      }
+    )
+  ).toEqual(null);
+
+  expect(
+    testReduceToScenario(
+      {
+        name: "emailAddress",
+        type: "String",
+        isArray: false,
+      },
+      {
+        scenario: undefined,
+        typeBuilders: {
+          User: () => ({
+            emailAddress: "type@example.com",
+          }),
+          String: () => "Mocked String",
+        },
+        nameBuilders: {
+          emailAddress: () => "name@example.com",
+        },
+      }
+    )
+  ).toEqual("Mocked String");
+
+  expect(
+    testReduceToScenario(
+      {
+        name: "emailAddress",
+        type: "String",
+        isArray: false,
+      },
+      {
+        scenario: undefined,
+        typeBuilders: {
+          User: () => ({
+            emailAddress: "type@example.com",
+          }),
+        },
+        nameBuilders: {
+          emailAddress: () => "name@example.com",
+        },
+      }
+    )
+  ).toEqual("name@example.com");
+
+  expect(
+    testReduceToScenario(
+      {
+        name: "allergies",
+        type: "String",
+        isArray: true,
+      },
+      {
+        scenario: [{}],
+        typeBuilders: {
+          User: () => ({
+            emailAddress: "type@example.com",
+          }),
+        },
+        nameBuilders: {
+          emailAddress: () => "name@example.com",
+        },
+      }
+    )
+  ).toEqual([{}]);
+
+  expect(
+    testReduceToScenario(
+      {
+        name: "allergies",
+        type: "String",
+        isArray: true,
+      },
+      {
+        scenario: undefined,
+        typeBuilders: {
+          User: () => ({
+            emailAddress: "type@example.com",
+          }),
+        },
+        nameBuilders: {
+          emailAddress: () => "name@example.com",
+        },
+      }
+    )
+  ).toEqual(undefined);
+
+  expect(
+    typeof testReduceToScenario(
+      {
+        name: "launches",
+        type: "LaunchConnection",
+        isArray: false,
+      },
+      {
+        scenario: () => () => {
+          // something
+        },
+        typeBuilders: {
+          User: () => ({
+            emailAddress: "type@example.com",
+            trips: [{ isBooked: false }],
+          }),
+          String: () => "Mocked String",
+        },
+        nameBuilders: {
+          profileImage: () => "http://example.com/profile.png",
+          me: () => ({
+            allergies: ["Aspirin"],
+            address: {
+              city: "New York City",
+            },
+          }),
+        },
+      }
+    )
+  ).toBe("function");
+});

--- a/packages/graphql-mirage/src/__test__/mockFields.test.js
+++ b/packages/graphql-mirage/src/__test__/mockFields.test.js
@@ -1,0 +1,330 @@
+const fs = require("fs");
+const path = require("path");
+const { times } = require("lodash");
+const schemaParser = require("easygraphql-parser");
+
+const { mockType, defaultBuiltInScalarBuilders } = require("../engine");
+
+const typeDefs = fs.readFileSync(
+  path.join(__dirname, "example.schema.graphql"),
+  "utf8"
+);
+
+const DEFAULT_ARRAY_LENGTH = 3;
+
+const schema = schemaParser(typeDefs);
+const mockQueryType = ({
+  scenario = {},
+  typeBuilders = {},
+  nameBuilders = {},
+} = {}) => {
+  return mockType("Query", schema, {
+    scenario,
+    typeBuilders: {
+      ...defaultBuiltInScalarBuilders,
+      ...typeBuilders,
+    },
+    nameBuilders,
+  });
+};
+
+describe("Scenario", () => {
+  it("SCENARIO: sets built-in scalar", () => {
+    const EMAIL = "me@example.com";
+
+    const actual = mockQueryType({
+      scenario: {
+        me: { email: EMAIL, profileImage: null },
+      },
+    });
+
+    expect(actual.me.email).toEqual(EMAIL);
+    expect(actual.me.profileImage).toBe(null);
+  });
+
+  it("SCENARIO: sets array of built-in scalars", () => {
+    const actual = mockQueryType({
+      scenario: {
+        me: {
+          allergies: ["Aspirin", "Peanuts"],
+        },
+      },
+    });
+
+    expect(actual.me.allergies).toHaveLength(2);
+    expect(actual.me.allergies[0]).toBe("Aspirin");
+    expect(actual.me.allergies[1]).toBe("Peanuts");
+  });
+
+  it("SCENARIO: sets deep Array of Object Types", () => {
+    const actual = mockQueryType({
+      scenario: {
+        me: {
+          trips: [
+            { site: "Kennedy Space Center" },
+            ...times(3, () => ({})),
+            { site: "Vandenberg Air Force Base" },
+          ],
+        },
+      },
+    });
+
+    expect(actual.me.trips).toHaveLength(5);
+    expect(actual.me.trips[0].site).toEqual("Kennedy Space Center");
+    expect(actual.me.trips[4].site).toEqual("Vandenberg Air Force Base");
+  });
+
+  it("SCENARIO: sets deep Array of Object Types recursively", () => {
+    const actual = mockQueryType({
+      scenario: {
+        me: {
+          trips: [{ rockets: [{ name: "Falcon 9" }, {}] }, {}],
+        },
+      },
+    });
+
+    expect(actual.me.trips[0].rockets).toHaveLength(2);
+    expect(actual.me.trips[0].rockets[0].name).toEqual("Falcon 9");
+    expect(actual.me.trips[1].rockets).toHaveLength(DEFAULT_ARRAY_LENGTH);
+  });
+});
+
+describe("Type Builders", () => {
+  it("TYPE: can set built-in scalar field value from Object Type Builder", () => {
+    const actual = mockQueryType({
+      scenario: {
+        me: {
+          trips: [
+            { site: "Kennedy Space Center" },
+            { mission: { name: "Alpha" } },
+          ],
+        },
+      },
+      typeBuilders: { Mission: () => ({ name: "Beta" }) },
+    });
+
+    expect(actual.me.trips[0].mission.name).toEqual("Beta");
+  });
+
+  it("TYPE: can set null values for *any* field from Object Type Builder", () => {
+    const actual = mockQueryType({
+      scenario: {
+        me: {
+          trips: [{ site: "Kennedy Space Center" }, {}],
+        },
+      },
+      typeBuilders: {
+        User: () => ({ profileImage: null }),
+        Launch: () => ({ rockets: null }),
+      },
+    });
+
+    expect(actual.me.profileImage).toBe(null);
+    expect(actual.me.trips[0].rockets).toBe(null);
+  });
+
+  it("TYPE: Object Type builders can set the shape of Array Object Type fields", () => {
+    const actual = mockQueryType({
+      typeBuilders: {
+        User: () => ({
+          trips: times(5, () => ({
+            rockets: [{ name: "Falcon Heavy" }, { type: "Small" }],
+          })),
+        }),
+      },
+    });
+
+    expect(actual.me.trips).toHaveLength(5);
+    expect(actual.me.trips[0].rockets).toHaveLength(2);
+    expect(actual.me.trips[0].rockets[0].name).toBe("Falcon Heavy");
+    expect(actual.me.trips[0].rockets[1].type).toBe("Small");
+  });
+
+  it("TYPE: can set Type Builder for Built-in Scalar Types", () => {
+    const actual = mockQueryType({
+      typeBuilders: {
+        ID: () => "GENERATED_ID",
+      },
+    });
+
+    expect(actual.me.id).toBe("GENERATED_ID");
+    expect(actual.me.trips[0].id).toBe("GENERATED_ID");
+  });
+
+  it("TYPE: Object Type builder does not ovewrite Scenario", () => {
+    const actual = mockQueryType({
+      scenario: {
+        me: {
+          profileImage: null,
+          email: "jim@example.com",
+          trips: [{ site: "Vandenberg Air Force Base" }, {}],
+        },
+      },
+      typeBuilders: {
+        User: () => ({
+          profileImage: "http://example.com/profile.png",
+          email: "test@example.com",
+        }),
+        Launch: () => ({ site: "Kennedy Space Center", rockets: null }),
+      },
+    });
+
+    // Does not overwrite null
+    expect(actual.me.profileImage).toBe(null);
+    // Does not overwrite with null
+    expect(actual.me.email).toBe("jim@example.com");
+    // Does not overwrite with null deep
+    expect(actual.me.trips[0].site).toEqual("Vandenberg Air Force Base");
+    // Redunant. Checking if merging works for fields that are not in scenario
+    expect(actual.me.trips[0].rockets).toEqual(null);
+  });
+
+  it("TYPE: Object Type has arguments", () => {
+    const actual = mockQueryType({
+      scenario: {
+        launches: {
+          list: times(5, (i) => ({
+            site: i % 2 ? "Odd Space Center" : "Even Space Center",
+          })),
+        },
+      },
+      typeBuilders: {
+        LaunchConnection: () => ({
+          list: (getLaunches) => {
+            return (_, { siteFilter }) => {
+              return getLaunches().filter((launch) => {
+                return launch.site.includes(siteFilter);
+              });
+            };
+          },
+        }),
+      },
+    });
+
+    expect(typeof actual.launches.list).toBe("function");
+    expect(actual.launches.list(null, { siteFilter: "Odd" })).toHaveLength(2);
+    expect(actual.launches.list(null, { siteFilter: "Even" })).toHaveLength(3);
+    // Checks if the closed value can be updated with a setter
+    // Useful for mutations
+    actual.launches.list = times(5, () => ({ site: "Odd" }));
+    expect(actual.launches.list(null, { siteFilter: "Odd" })).toHaveLength(5);
+  });
+});
+
+describe("Name Builders", () => {
+  it("NAME: works when no Scenario or Object Type builder present", () => {
+    const actual = mockQueryType({
+      nameBuilders: {
+        id: () => "NAME_BUILDER_ID",
+      },
+    });
+
+    expect(actual.me.id).toEqual("NAME_BUILDER_ID");
+    expect(actual.me.trips[0].id).toEqual("NAME_BUILDER_ID");
+    expect(actual.me.trips[0].rockets[0].id).toEqual("NAME_BUILDER_ID");
+  });
+
+  it("NAME: does not overwrite Scenario", () => {
+    const actual = mockQueryType({
+      scenario: { me: { id: "SCENARIO_ID" } },
+      nameBuilders: {
+        id: () => "NAME_BUILDER_ID",
+      },
+    });
+
+    expect(actual.me.id).toEqual("SCENARIO_ID");
+  });
+
+  it("NAME: does not overwrite Object Type builder", () => {
+    const actual = mockQueryType({
+      typeBuilders: {
+        User: () => ({
+          id: "OBJECT_BUILDER_ID",
+        }),
+      },
+      nameBuilders: {
+        id: () => "NAME_BUILDER_ID",
+      },
+    });
+
+    expect(actual.me.id).toEqual("OBJECT_BUILDER_ID");
+  });
+});
+
+describe("Enums", () => {
+  it("ENUM: selects the first value of the enum", () => {
+    const actual = mockQueryType();
+    const enumValues = ["FEMALE", "MALE", "NON_BINARY"];
+
+    expect(actual.me.gender).toBe(enumValues[0]);
+  });
+});
+
+describe("Scalars", () => {
+  it("SCALAR: uses Type builder to generate scalar value", () => {
+    const DATE = "1989-12-16";
+    const actual = mockQueryType({
+      typeBuilders: {
+        Date: () => DATE,
+      },
+    });
+
+    expect(actual.me.dateOfBirth).toBe(DATE);
+  });
+});
+
+describe("Interfaces", () => {
+  it("INTERFACE: automatically selects the first concrete type when __typename is missing", () => {
+    const actual = mockQueryType();
+    const concreteTypes = ["Planet", "Star"];
+
+    expect(actual.me.trips[0].destination.__typename).toBe(concreteTypes[0]);
+  });
+
+  it("INTERFACE: can set custom concrete type from scenario using __typename", () => {
+    const actual = mockQueryType({
+      scenario: {
+        me: {
+          trips: [
+            {
+              destination: { __typename: "Star" },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(actual.me.trips[0].destination.__typename).toBe("Star");
+  });
+});
+
+describe("Unions", () => {
+  it("UNION: automatically selects the first concrete type when __typename is missing", () => {
+    const actual = mockQueryType({
+      scenario: {
+        me: { hobbies: [{}] },
+      },
+    });
+    const concreteTypes = ["ReadingHobby", "KarateHobby"];
+
+    actual.me.hobbies.map((hobby) =>
+      expect(hobby.__typename).toBe(concreteTypes[0])
+    );
+  });
+
+  it("UNION: uses Concrete Type instead of Interface Type when __typename is specified", () => {
+    const actual = mockQueryType({
+      scenario: {
+        me: {
+          hobbies: [
+            { __typename: "ReadingHobby" },
+            { __typename: "KarateHobby" },
+          ],
+        },
+      },
+    });
+
+    expect(actual.me.hobbies[0].__typename).toBe("ReadingHobby");
+    expect(actual.me.hobbies[1].__typename).toBe("KarateHobby");
+  });
+});

--- a/packages/graphql-mirage/src/__test__/mockFields.test.js
+++ b/packages/graphql-mirage/src/__test__/mockFields.test.js
@@ -3,7 +3,7 @@ const path = require("path");
 const { times } = require("lodash");
 const schemaParser = require("easygraphql-parser");
 
-const { mockType, defaultBuiltInScalarBuilders } = require("../engine");
+const { mockObjectType } = require("../engine");
 
 const typeDefs = fs.readFileSync(
   path.join(__dirname, "example.schema.graphql"),
@@ -13,17 +13,10 @@ const typeDefs = fs.readFileSync(
 const DEFAULT_ARRAY_LENGTH = 3;
 
 const schema = schemaParser(typeDefs);
-const mockQueryType = ({
-  scenario = {},
-  typeBuilders = {},
-  nameBuilders = {},
-} = {}) => {
-  return mockType("Query", schema, {
+const mockQueryType = ({ scenario, typeBuilders, nameBuilders } = {}) => {
+  return mockObjectType("Query", schema, {
     scenario,
-    typeBuilders: {
-      ...defaultBuiltInScalarBuilders,
-      ...typeBuilders,
-    },
+    typeBuilders,
     nameBuilders,
   });
 };

--- a/packages/graphql-mirage/src/__test__/mockObjectType.test.js
+++ b/packages/graphql-mirage/src/__test__/mockObjectType.test.js
@@ -21,37 +21,67 @@ const mockQuery = ({ scenario, typeBuilders, nameBuilders } = {}) => {
   });
 };
 
-// describe("Validation", () => {
-//   it("SCENARIO: should be validated against the schema", () => {
-//     expect(
-//       mockQuery({
-//         scenario: {
-//           me: { email: null },
-//         },
-//       })
-//     ).toThrowError();
-//   });
+describe("Validation", () => {
+  it("Should throw an error when the type builder isn't a function", () => {
+    expect(() =>
+      mockQuery({
+        typeBuilders: {
+          User: { email: null },
+        },
+      })
+    ).toThrow(TypeError);
+  });
 
-//   it("TYPE: should be validated against the schema", () => {
-//     expect(
-//       mockQuery({
-//         typeBuilders: {
-//           User: () => ({ email: null }),
-//         },
-//       })
-//     ).toThrowError();
-//   });
+  it("Should throw an error when the name builder isn't a function", () => {
+    expect(() =>
+      mockQuery({
+        nameBuilders: {
+          id: null,
+        },
+      })
+    ).toThrow(TypeError);
+  });
 
-//   it("NAME: should be validated agains the schema", () => {
-//     expect(
-//       mockQuery({
-//         nameBuilders: {
-//           id: () => null,
-//         },
-//       })
-//     ).toThrowError();
-//   });
-// });
+  it("SCENARIO: Should throw an error when we attempt to set a non-nullable field as null.", () => {
+    expect(() =>
+      mockQuery({
+        scenario: {
+          me: { email: null },
+        },
+      })
+    ).toThrowError();
+  });
+
+  it("SCENARIO: Should throw an error when we attempt to set a list with a primitive.", () => {
+    expect(() =>
+      mockQuery({
+        scenario: {
+          me: { allergies: "test" },
+        },
+      })
+    ).toThrowError();
+  });
+
+  it("TYPE: Should throw an error when we attempt to set a non-nullable field as null.", () => {
+    expect(() =>
+      mockQuery({
+        typeBuilders: {
+          User: () => ({ email: null }),
+        },
+      })
+    ).toThrowError();
+  });
+
+  it("NAME: Should throw an error when we attempt to set a non-nullable field as null.", () => {
+    expect(() =>
+      mockQuery({
+        nameBuilders: {
+          id: () => null,
+        },
+      })
+    ).toThrowError();
+  });
+});
 
 describe("Scenario", () => {
   it("SCENARIO: sets built-in scalar", () => {

--- a/packages/graphql-mirage/src/__test__/mockObjectType.test.js
+++ b/packages/graphql-mirage/src/__test__/mockObjectType.test.js
@@ -13,7 +13,7 @@ const typeDefs = fs.readFileSync(
 const DEFAULT_ARRAY_LENGTH = 3;
 
 const schema = schemaParser(typeDefs);
-const mockQueryType = ({ scenario, typeBuilders, nameBuilders } = {}) => {
+const mockQuery = ({ scenario, typeBuilders, nameBuilders } = {}) => {
   return mockObjectType("Query", schema, {
     scenario,
     typeBuilders,
@@ -21,11 +21,43 @@ const mockQueryType = ({ scenario, typeBuilders, nameBuilders } = {}) => {
   });
 };
 
+// describe("Validation", () => {
+//   it("SCENARIO: should be validated against the schema", () => {
+//     expect(
+//       mockQuery({
+//         scenario: {
+//           me: { email: null },
+//         },
+//       })
+//     ).toThrowError();
+//   });
+
+//   it("TYPE: should be validated against the schema", () => {
+//     expect(
+//       mockQuery({
+//         typeBuilders: {
+//           User: () => ({ email: null }),
+//         },
+//       })
+//     ).toThrowError();
+//   });
+
+//   it("NAME: should be validated agains the schema", () => {
+//     expect(
+//       mockQuery({
+//         nameBuilders: {
+//           id: () => null,
+//         },
+//       })
+//     ).toThrowError();
+//   });
+// });
+
 describe("Scenario", () => {
   it("SCENARIO: sets built-in scalar", () => {
     const EMAIL = "me@example.com";
 
-    const actual = mockQueryType({
+    const actual = mockQuery({
       scenario: {
         me: { email: EMAIL, profileImage: null },
       },
@@ -36,7 +68,7 @@ describe("Scenario", () => {
   });
 
   it("SCENARIO: sets array of built-in scalars", () => {
-    const actual = mockQueryType({
+    const actual = mockQuery({
       scenario: {
         me: {
           allergies: ["Aspirin", "Peanuts"],
@@ -50,7 +82,7 @@ describe("Scenario", () => {
   });
 
   it("SCENARIO: sets deep Array of Object Types", () => {
-    const actual = mockQueryType({
+    const actual = mockQuery({
       scenario: {
         me: {
           trips: [
@@ -68,7 +100,7 @@ describe("Scenario", () => {
   });
 
   it("SCENARIO: sets deep Array of Object Types recursively", () => {
-    const actual = mockQueryType({
+    const actual = mockQuery({
       scenario: {
         me: {
           trips: [{ rockets: [{ name: "Falcon 9" }, {}] }, {}],
@@ -84,7 +116,7 @@ describe("Scenario", () => {
 
 describe("Type Builders", () => {
   it("TYPE: can set built-in scalar field value from Object Type Builder", () => {
-    const actual = mockQueryType({
+    const actual = mockQuery({
       scenario: {
         me: {
           trips: [
@@ -100,7 +132,7 @@ describe("Type Builders", () => {
   });
 
   it("TYPE: can set null values for *any* field from Object Type Builder", () => {
-    const actual = mockQueryType({
+    const actual = mockQuery({
       scenario: {
         me: {
           trips: [{ site: "Kennedy Space Center" }, {}],
@@ -117,7 +149,7 @@ describe("Type Builders", () => {
   });
 
   it("TYPE: Object Type builders can set the shape of Array Object Type fields", () => {
-    const actual = mockQueryType({
+    const actual = mockQuery({
       typeBuilders: {
         User: () => ({
           trips: times(5, () => ({
@@ -134,7 +166,7 @@ describe("Type Builders", () => {
   });
 
   it("TYPE: can set Type Builder for Built-in Scalar Types", () => {
-    const actual = mockQueryType({
+    const actual = mockQuery({
       typeBuilders: {
         ID: () => "GENERATED_ID",
       },
@@ -145,7 +177,7 @@ describe("Type Builders", () => {
   });
 
   it("TYPE: Object Type builder does not ovewrite Scenario", () => {
-    const actual = mockQueryType({
+    const actual = mockQuery({
       scenario: {
         me: {
           profileImage: null,
@@ -173,7 +205,7 @@ describe("Type Builders", () => {
   });
 
   it("TYPE: Object Type has arguments", () => {
-    const actual = mockQueryType({
+    const actual = mockQuery({
       scenario: {
         launches: {
           list: times(5, (i) => ({
@@ -206,7 +238,7 @@ describe("Type Builders", () => {
 
 describe("Name Builders", () => {
   it("NAME: works when no Scenario or Object Type builder present", () => {
-    const actual = mockQueryType({
+    const actual = mockQuery({
       nameBuilders: {
         id: () => "NAME_BUILDER_ID",
       },
@@ -218,7 +250,7 @@ describe("Name Builders", () => {
   });
 
   it("NAME: does not overwrite Scenario", () => {
-    const actual = mockQueryType({
+    const actual = mockQuery({
       scenario: { me: { id: "SCENARIO_ID" } },
       nameBuilders: {
         id: () => "NAME_BUILDER_ID",
@@ -229,7 +261,7 @@ describe("Name Builders", () => {
   });
 
   it("NAME: does not overwrite Object Type builder", () => {
-    const actual = mockQueryType({
+    const actual = mockQuery({
       typeBuilders: {
         User: () => ({
           id: "OBJECT_BUILDER_ID",
@@ -246,7 +278,7 @@ describe("Name Builders", () => {
 
 describe("Enums", () => {
   it("ENUM: selects the first value of the enum", () => {
-    const actual = mockQueryType();
+    const actual = mockQuery();
     const enumValues = ["FEMALE", "MALE", "NON_BINARY"];
 
     expect(actual.me.gender).toBe(enumValues[0]);
@@ -256,7 +288,7 @@ describe("Enums", () => {
 describe("Scalars", () => {
   it("SCALAR: uses Type builder to generate scalar value", () => {
     const DATE = "1989-12-16";
-    const actual = mockQueryType({
+    const actual = mockQuery({
       typeBuilders: {
         Date: () => DATE,
       },
@@ -268,14 +300,14 @@ describe("Scalars", () => {
 
 describe("Interfaces", () => {
   it("INTERFACE: automatically selects the first concrete type when __typename is missing", () => {
-    const actual = mockQueryType();
+    const actual = mockQuery();
     const concreteTypes = ["Planet", "Star"];
 
     expect(actual.me.trips[0].destination.__typename).toBe(concreteTypes[0]);
   });
 
   it("INTERFACE: can set custom concrete type from scenario using __typename", () => {
-    const actual = mockQueryType({
+    const actual = mockQuery({
       scenario: {
         me: {
           trips: [
@@ -293,7 +325,7 @@ describe("Interfaces", () => {
 
 describe("Unions", () => {
   it("UNION: automatically selects the first concrete type when __typename is missing", () => {
-    const actual = mockQueryType({
+    const actual = mockQuery({
       scenario: {
         me: { hobbies: [{}] },
       },
@@ -306,7 +338,7 @@ describe("Unions", () => {
   });
 
   it("UNION: uses Concrete Type instead of Interface Type when __typename is specified", () => {
-    const actual = mockQueryType({
+    const actual = mockQuery({
       scenario: {
         me: {
           hobbies: [

--- a/packages/graphql-mirage/src/constants.js
+++ b/packages/graphql-mirage/src/constants.js
@@ -5,7 +5,7 @@ const constants = {
   int: "Int",
   float: "Float",
   boolean: "Boolean",
-  scalar: "ScalarTypeDefinition",
+  customScalar: "ScalarTypeDefinition",
   interface: "InterfaceTypeDefinition",
 };
 

--- a/packages/graphql-mirage/src/constants.js
+++ b/packages/graphql-mirage/src/constants.js
@@ -7,7 +7,6 @@ const constants = {
   boolean: "Boolean",
   scalar: "ScalarTypeDefinition",
   interface: "InterfaceTypeDefinition",
-  customScalar: "CustomScalar",
 };
 
 module.exports = constants;

--- a/packages/graphql-mirage/src/constants.js
+++ b/packages/graphql-mirage/src/constants.js
@@ -1,12 +1,13 @@
 const constants = {
-  ID: 'ID',
-  id: 'id',
-  string: 'String',
-  int: 'Int',
-  float: 'Float',
-  boolean: 'Boolean',
-  scalar: 'ScalarTypeDefinition',
-  interface: 'InterfaceTypeDefinition',
+  ID: "ID",
+  id: "id",
+  string: "String",
+  int: "Int",
+  float: "Float",
+  boolean: "Boolean",
+  scalar: "ScalarTypeDefinition",
+  interface: "InterfaceTypeDefinition",
+  customScalar: "CustomScalar",
 };
 
 module.exports = constants;

--- a/packages/graphql-mirage/src/helpers.js
+++ b/packages/graphql-mirage/src/helpers.js
@@ -1,56 +1,48 @@
-const { mergeWith, memoize } = require('lodash');
+const { mergeWith, memoize } = require("lodash");
 
-const constants = require('./constants');
+const constants = require("./constants");
 
-function isUndefined(value) {
-  return typeof value === 'undefined';
-}
-
-function hasProp(object, prop) {
-  return !isUndefined(object) && !isUndefined(object[prop]);
-}
-
-function getEnumVal(type, schema) {
-  return schema[type].values[0];
-}
-
-function getUnionVal(type, schema) {
-  return schema[type].types[0];
-}
-
-function getConcreteType(type, schema) {
-  return schema[type].implementedTypes[0];
-}
-
-function getUnionVals(type, schema) {
-  return schema[type].types;
-}
-
-function isUnionType(type, schema) {
-  return schema[type] && schema[type].types.length > 0;
-}
-
-function isEnumType(type, schema) {
-  return schema[type] && schema[type].values.length > 0;
-}
-
-function isScalarType(type, schema) {
-  return schema[type] && schema[type].type === constants.scalar;
-}
-
-function isInterfaceType(type, schema) {
-  return schema[type] && schema[type].type === constants.interface;
-}
-
-function isBuiltInScalarType(type) {
-  return [
+// Scalar Helpers
+const isBuiltInScalarType = (type) =>
+  [
     constants.int,
     constants.float,
     constants.string,
     constants.boolean,
     constants.ID,
   ].includes(type);
-}
+const isCustomScalarType = (type, schema) =>
+  schema[type] && schema[type].type === constants.scalar;
+const isScalarType = (type, schema) =>
+  isCustomScalarType(type, schema) || isBuiltInScalarType(type);
+// Enums
+const getEnumVal = (type, schema) => schema[type].values[0];
+const isEnumType = (type, schema) =>
+  schema[type] && schema[type].values.length > 0;
+// Object Types
+const isObjectType = (type, schema) =>
+  !isScalarType(type, schema) && !isEnumType(type, schema);
+// Abstract Types
+const isInterfaceType = (type, schema) =>
+  schema[type] && schema[type].type === constants.interface;
+const isUnionType = (type, schema) =>
+  schema[type] && schema[type].types.length > 0;
+const isAbstractType = (type, schema) =>
+  isUnionType(type, schema) || isInterfaceType(type, schema);
+const getUnionVal = (type, schema) => schema[type].types[0];
+const getUnionVals = (type, schema) => schema[type].types;
+const getConcreteType = (type, schema) => {
+  if (isInterfaceType(type, schema)) {
+    // https://github.com/EasyGraphQL/easygraphql-parser/issues/9
+    return schema[type].implementedTypes[0];
+  } else if (isUnionType(type, schema)) {
+    return getUnionVal(type, schema);
+  }
+};
+
+const isUndefined = (value) => typeof value === "undefined";
+const hasProp = (object, prop) =>
+  !isUndefined(object) && !isUndefined(object[prop]);
 
 const getScenarioFn = (defaultScenario = {}) =>
   memoize(function getScenario(customScenario = {}) {
@@ -78,45 +70,45 @@ const getTypeBuildersFn = (defaults = {}) =>
     };
   }, JSON.stringify);
 
-function mergeDataSources(defaults = {}, custom = {}) {
+const mergeDataSources = (defaults = {}, custom = {}) => {
   return {
     scenario: getScenarioFn(defaults.scenario)(custom.scenario),
     nameBuilders: getNameBuildersFn(defaults.nameBuilders)(custom.nameBuilders),
     typeBuilders: getTypeBuildersFn(defaults.typeBuilders)(custom.typeBuilders),
   };
-}
+};
 
-function getDebugger(DEBUGGING) {
+const getDebugger = (DEBUGGING) => {
   let debuggerState = {
     types: new Set(),
     fields: new Set(),
   };
   return function debug(type, field) {
     if (!DEBUGGING) return;
-    console.log('DOES NOT WORK PROPERLY');
+    console.log("DOES NOT WORK PROPERLY");
     const { types, fields } = debuggerState;
-    const getSpaces = (size, char = '-') => {
-      return size ? `${char.repeat(size)}` : '';
+    const getSpaces = (size, char = "-") => {
+      return size ? `${char.repeat(size)}` : "";
     };
     if (type) {
       types.add(type);
       console.log(
-        `L${types.size - 1} ${getSpaces(types.size, '- ')} TYPE: ${type}`
+        `L${types.size - 1} ${getSpaces(types.size, "- ")} TYPE: ${type}`
       );
     } else if (field) {
       fields.add(field);
 
       console.log(
-        `L${types.size - 1} ${getSpaces(types.size, ' ')} FIELD: ${field}`
+        `L${types.size - 1} ${getSpaces(types.size, " ")} FIELD: ${field}`
       );
     }
   };
-}
+};
 
 // Displays duplicates in the cache, and what part of the key is different.
 // Usually this happens for the scenario.
 // Helpful to debug performance.
-function debugCacheDuplicates(cache, meta = {}) {
+const debugCacheDuplicates = (cache, meta = {}) => {
   const keys = cache._keys.map((key) => key[0]);
 
   // Lists the keys for inspection of duplication
@@ -130,7 +122,7 @@ function debugCacheDuplicates(cache, meta = {}) {
       (key) => key[0] === meta.showDifferenceForType
     );
     if (duplicates.length > 2) {
-      const keyParts = ['type', 'names', 'types', 'scenario'];
+      const keyParts = ["type", "names", "types", "scenario"];
       duplicates.slice(0, -1).forEach((duplicate, index) => {
         duplicates.slice(index + 1).forEach((nextDup, jindex) => {
           duplicate.map((testedKeyPart, i) => {
@@ -145,28 +137,30 @@ function debugCacheDuplicates(cache, meta = {}) {
       });
     } else if (duplicates.length) {
       console.log(
-        'Are equal',
+        "Are equal",
         duplicates[0].reduce((res, keyPart, i) => {
           if (keyPart !== duplicates[1][i]) {
-            console.log('DIFFERENT:', { zero: keyPart, one: duplicates[1][i] });
+            console.log("DIFFERENT:", { zero: keyPart, one: duplicates[1][i] });
           }
           return res && keyPart === duplicates[1][i];
         }, true)
       );
     }
   }
-}
+};
 
 module.exports = {
   getUnionVal,
   getUnionVals,
   getEnumVal,
   getConcreteType,
-  isUnionType,
   isEnumType,
   isBuiltInScalarType,
+  isCustomScalarType,
   isScalarType,
+  isUnionType,
   isInterfaceType,
+  isAbstractType,
   getScenarioFn,
   getNameBuildersFn,
   getTypeBuildersFn,
@@ -175,4 +169,5 @@ module.exports = {
   mergeDataSources,
   getDebugger,
   debugCacheDuplicates,
+  isObjectType,
 };

--- a/packages/graphql-mirage/src/index.js
+++ b/packages/graphql-mirage/src/index.js
@@ -1,12 +1,12 @@
 const {
   makeExecutableSchema,
   addMockFunctionsToSchema,
-} = require('graphql-tools');
-const schemaParser = require('easygraphql-parser');
-const { mapValues, memoize } = require('lodash');
+} = require("graphql-tools");
+const schemaParser = require("easygraphql-parser");
+const { mapValues, memoize } = require("lodash");
 
-const { mockType, defaultBuiltInScalarBuilders } = require('./engine');
-const { getScenarioFn, mergeDataSources } = require('./helpers');
+const { mockObjectType } = require("./engine");
+const { getScenarioFn, mergeDataSources } = require("./helpers");
 
 // Returns the same cached result if the `type`, `defaults`, `custom`,
 // and `selector` arguments do not change.
@@ -14,7 +14,7 @@ const buildMocks = memoize(
   function buildMocks(type, schema, defaults = {}, custom = {}) {
     // if (type !== 'Query' && selector) {
     //   // When we use `buildMocks` to generate Object Types (in the context of mutations)
-    //   // we want to sub-select a part of the scenario in order to have `mockType`
+    //   // we want to sub-select a part of the scenario in order to have `mockObjectType`
     //   // walk the correct tree of scenario data.
     //   defaults = {
     //     ...defaults,
@@ -22,7 +22,7 @@ const buildMocks = memoize(
     //   };
     // }
 
-    return mockType(type, schema, mergeDataSources(defaults, custom));
+    return mockObjectType(type, schema, mergeDataSources(defaults, custom));
   },
   (type, _, defaults, custom, selector) =>
     JSON.stringify({
@@ -50,17 +50,7 @@ function getExecutableSchema(
   const schema = schemaParser(typeDefs);
 
   const getMemoizedDefaultDataSources = memoize(
-    (context) => {
-      const defaultDataSources = getDefaultDataSources(context);
-
-      return {
-        ...defaultDataSources,
-        typeBuilders: {
-          ...defaultBuiltInScalarBuilders,
-          ...defaultDataSources.typeBuilders,
-        },
-      };
-    },
+    getDefaultDataSources,
     (context) => JSON.stringify(context)
   );
 
@@ -76,7 +66,7 @@ function getExecutableSchema(
     // Partial application of buildMocks to be passed down to the Mutation resolvers
     // This function will be called to generate data for a certain type in the Mutation
     // resolver
-    function buildMocksForType(type, selector = '', scenario = {}) {
+    function buildMocksForType(type, selector = "", scenario = {}) {
       return buildMocks(
         type,
         schema,
@@ -96,7 +86,7 @@ function getExecutableSchema(
   // Generates mocks for the Query node. Essentially our initial data store.
   const _getMockedQuery = (context) => {
     return buildMocks(
-      'Query',
+      "Query",
       schema,
       getMemoizedDefaultDataSources(context),
       customDataSources
@@ -109,7 +99,7 @@ function getExecutableSchema(
     mocks: {
       Query: (root, args, context) =>
         mapValues(_getMockedQuery(context), (val) =>
-          typeof val === 'function' ? val : () => val
+          typeof val === "function" ? val : () => val
         ),
 
       Mutation: (root, args, context) =>

--- a/packages/graphql-mirage/src/validation.js
+++ b/packages/graphql-mirage/src/validation.js
@@ -1,0 +1,53 @@
+const { isUndefined, isNull, isFunction } = require("lodash");
+
+// INSTANTIANTE VALIDATOR WITH GLOBALS?
+
+/**
+ * Validates a Type or Name builder.
+ * Throws a TypeError if the builder isn't a function.
+ *
+ * @param {Object} field
+ * @param {any} builder
+ * @param {"type" | "name"} kind
+ */
+const validateBuilder = (builder, field, kind) => {
+  if (!isUndefined(builder) && !isFunction(builder)) {
+    throw new TypeError(
+      `All builders need to be functions. The "${field[kind]}" ${kind} builder sn't a function.`
+    );
+  }
+  return true;
+};
+
+/**
+ * Validates a Scenario for a specifc field.
+ * Check for non-nullable and array issues.
+ *
+ * @param {Object} field
+ * @param {any} builder
+ * @param {"type" | "name"} kind
+ */
+const validateScenario = (scenario, field, path) => {
+  if (isUndefined(scenario)) {
+    return;
+  }
+
+  if (isNull(scenario) && field.noNull) {
+    throw new TypeError(
+      `You are attempting to mock the non-nullable "${path}" field with "null".`
+    );
+  }
+
+  if (!isNull(scenario) && !Array.isArray(scenario) && field.isArray) {
+    throw new TypeError(
+      `You are attempting to mock the the list "${path}" field with non-array value "${scenario}". List fields must be mocked with arrays.`
+    );
+  }
+
+  // TODO: Check if scenario is array and field is not array
+};
+
+module.exports = {
+  validateScenario,
+  validateBuilder,
+};


### PR DESCRIPTION
- Updated test and example schema: we're using the Space X Apollo schema, slightly modified in order to suit our testing needs
- Added data sources validation: TypeErrors are thrown if scenarios data or builder values aren't conforming to the types defined in the schema
- Type builder field values can now be scenarios, and so do Name builder return values
- Type and Name builders must now be functions
- Logic has been simplified: All custom data sources are merged into a single scenario before mocking the data.
- New functionality has been tested.

__Do not merge please__